### PR TITLE
Add kinfraglib filters module (skeleton)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - rdkit=2020.03.3
   - scikit-learn
   - seaborn
+  - lich::syba
   ## CI tests
   # Workaround for https://github.com/computationalmodelling/nbval/issues/153
   - pytest 5.*

--- a/kinfraglib/__init__.py
+++ b/kinfraglib/__init__.py
@@ -1,0 +1,1 @@
+from . import utils, filters

--- a/kinfraglib/filters/__init__.py
+++ b/kinfraglib/filters/__init__.py
@@ -1,0 +1,1 @@
+from . import syba, plots

--- a/kinfraglib/filters/plots.py
+++ b/kinfraglib/filters/plots.py
@@ -1,0 +1,3 @@
+"""
+Contains plotting functionalities for different filters.
+"""

--- a/kinfraglib/filters/plots.py
+++ b/kinfraglib/filters/plots.py
@@ -1,3 +1,47 @@
 """
 Contains plotting functionalities for different filters.
 """
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+import statistics
+
+def make_hists(values_list, fragment_library, filtername = None, plot_stats = True, cutoff = None):
+    """
+    Creates a histogram for each subpocket.
+    
+    Parameters
+    ----------
+    values_list : pandas.Series
+        smiles series containing fragment smiles strings
+
+    fragment_library : dict of pandas.DataFrame
+        Fragment details, i.e. SMILES, and fragment RDKit molecules, KLIFS and fragmentation details (values)
+        for each subpocket (key).
+
+    filtername : str
+        name of the filter creating the values plottet
+
+    cutoff : int or float
+    """
+    #get even number if number of plots not even
+    num_plots = round(len(values_list)+0.5)
+    fig = plt.figure(figsize=(20, 22))
+    gs = gridspec.GridSpec(int(num_plots/2),int(num_plots/2))
+    keys = list(fragment_library.keys())
+    for i in range(0, 2):
+        for j in range(0, int((num_plots)/2)):
+            if (i*4)+j < num_plots-1:
+                ax = plt.subplot(gs[i,j])
+                ax.hist(values_list[((i*4)+j)], facecolor = '#04D8B2', edgecolor='#808080')
+                ax.set_title(keys[((i*4)+j)])
+                if plot_stats:
+                    plt.plot([], [], ' ', label="mean: "+str(round(statistics.mean(values_list[((i*4)+j)]))))
+                    plt.plot([], [], ' ', label="min: "+str(round(min(values_list[((i*4)+j)]))))
+                    plt.plot([], [], ' ', label="max: "+str(round(max(values_list[((i*4)+j)]))))
+                    plt.legend()
+                if not cutoff is None:
+                    plt.axvline(x=cutoff, color='r', linestyle='-')
+                if not filtername is None:
+                    plt.xlabel(filtername)
+                plt.ylabel("Number of fragments")         
+    plt.suptitle(filtername)

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -12,7 +12,6 @@ def calc_syba(smiles_series):
     smiles_series : pandas.Series
         smiles series containing fragment smiles strings
     
-    
     Returns
     -------
     ??array??

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -1,3 +1,26 @@
 """
 Contains the SYBA filter.
 """
+from syba.syba import SybaClassifier
+
+def calc_syba(smiles_series):
+    """
+    Go through SMILES Series ans calculate the SYnthetic Bayesian Accessibility.
+    
+    Parameters
+    ----------
+    smiles_series : pandas.Series
+        smiles series containing fragment smiles strings
+    
+    
+    Returns
+    -------
+    ??array??
+        SYBA value for each SMILES
+    """
+    sybas = []
+    syba = SybaClassifier()
+    syba.fitDefaultScore()
+    for smiles in smiles_series:
+        sybas.append(syba.predict(smiles))
+    return sybas

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -1,0 +1,3 @@
+"""
+Contains the SYBA filter.
+"""

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -5,7 +5,7 @@ from syba.syba import SybaClassifier
 
 def calc_syba(smiles_series):
     """
-    Go through SMILES Series ans calculate the SYnthetic Bayesian Accessibility.
+    Go through SMILES Series and calculate the SYnthetic Bayesian Accessibility.
     
     Parameters
     ----------
@@ -14,7 +14,7 @@ def calc_syba(smiles_series):
     
     Returns
     -------
-    ??array??
+    list
         SYBA value for each SMILES
     """
     sybas = []

--- a/kinfraglib/filters/syba.py
+++ b/kinfraglib/filters/syba.py
@@ -14,7 +14,7 @@ def calc_syba(smiles_series):
     
     Returns
     -------
-    list
+    list of floats
         SYBA value for each SMILES
     """
     sybas = []


### PR DESCRIPTION
## Description
Add a first skeleton for Custom-KinFragLib filters (could also become the home of existing filters, e.g. Ro3, living currently in `kinfraglib.utils`).

## Todos
  - [x] Add `kinfraglib.filters`
  - [x] Add `kinfraglib.filters.syba` skeleton submodule
  - [ ] Add `kinfraglib.filters.plots` skeleton submodule that shall contain generalized plotting function for the different filters
  - [ ] change notebooks folder names
  - [ ] upload first notebook (e.g. SYBA)

## Questions
- [ ] organize notebooks in folder `custom_filters_notebooks` for my notebooks?
- [ ] rename old kinfraglib `notebooks` folder to sth like `kinfraglib_notebook'`?

## Status
- [ ] Ready to go